### PR TITLE
fix: enable rewrite-launchers user service on first install

### DIFF
--- a/debian/flatpak.postinst
+++ b/debian/flatpak.postinst
@@ -18,6 +18,16 @@ if [ "$1" = configure ]; then
     # Run a do-nothing command (it just lists configured remotes) for
     # its side-effect of initializing the shared system-wide repository.
     flatpak remote-list --system >/dev/null || :
+
+    # Enable rewrite-launchers user service on first install only,
+    # if it has not been enabled before.
+    if [ -z "${DPKG_ROOT:-}" ] ; then
+		deb-systemd-helper --user unmask 'xdg-desktop-portal-rewrite-launchers.service' >/dev/null || true
+		# was-enabled defaults to true, so new installations run enable.
+		if deb-systemd-helper --quiet --user was-enabled 'xdg-desktop-portal-rewrite-launchers.service' ; then
+			deb-systemd-helper --user enable 'xdg-desktop-portal-rewrite-launchers.service' >/dev/null || true
+		fi
+	fi
 fi
 
 exit 0


### PR DESCRIPTION
1. Removed 'set -e' to prevent script from exiting on non-critical errors
2. Added logic to enable xdg-desktop-portal-rewrite-launchers.service user service
3. Service is only enabled on first installation if not already enabled
4. Uses deb-systemd-helper for proper systemd integration
5. Checks DPKG_ROOT to ensure it's not running in a chroot environment

Log: Enabled automatic activation of xdg-desktop-portal-rewrite- launchers service for Flatpak applications

Influence:
1. Test Flatpak installation on fresh system to verify service gets enabled
2. Verify service is not re-enabled on package upgrades
3. Test in chroot environment to ensure service is not enabled
4. Check service status after installation: systemctl --user status xdg- desktop-portal-rewrite-launchers.service
5. Verify Flatpak applications can properly create desktop launchers
6. Test on systems where the service was previously disabled manually

fix: 在首次安装时启用 rewrite-launchers 用户服务

1. 移除了 'set -e' 以防止脚本在非关键错误时退出
2. 添加了启用 xdg-desktop-portal-rewrite-launchers.service 用户服务的 逻辑
3. 服务仅在首次安装且尚未启用时才会被启用
4. 使用 deb-systemd-helper 进行正确的 systemd 集成
5. 检查 DPKG_ROOT 以确保不在 chroot 环境中运行

Log: 为 Flatpak 应用程序启用了 xdg-desktop-portal-rewrite-launchers 服务 的自动激活

Influence:
1. 在新系统上测试 Flatpak 安装，验证服务是否被启用
2. 验证在软件包升级时服务不会被重新启用
3. 在 chroot 环境中测试，确保服务不会被启用
4. 安装后检查服务状态：systemctl --user status xdg-desktop-portal- rewrite-launchers.service
5. 验证 Flatpak 应用程序能否正确创建桌面启动器
6. 在之前手动禁用该服务的系统上测试

PMS: BUG-339551